### PR TITLE
Add self-tests to claude-git-dash-c-check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,9 +143,13 @@ tests can't run exits non-zero.
   world through PATH, a stub directory prepended to PATH is enough, and any variable
   whose ambient value would decide a case has to be unset in the test environment
   (`claude-notify-push` unsets `CLAUDE_NOTIFY_PUSH_DISABLED` and `ZELLIJ`, both of
-  which are set in a real session). What stays un-self-tested is state no stub stands
-  in for: `claude-uv-check` needs a uv project, `claude-git-dash-c-check` a specific
-  git repo, `claude-user-away` a terminal someone has typed into.
+  which are set in a real session). Where a hook needs a specific git repo,
+  building one with `git init` in a `mktemp -d` sandbox and `cd`-ing into it before
+  re-invoking the hook is enough: `claude-git-dash-c-check` does this to test
+  blocking on the repo root, on `.`, and from a subdirectory, while allowing a
+  different repo. What stays un-self-tested is state no stub stands in for:
+  `claude-uv-check` needs a uv project, `claude-user-away` a terminal someone has
+  typed into.
 - A passing self-test that cannot fail is worth nothing, so confirm a new case catches
   a deliberately broken copy of the hook before trusting it.
 

--- a/bin/claude-git-dash-c-check
+++ b/bin/claude-git-dash-c-check
@@ -5,6 +5,45 @@
 
 set -euo pipefail
 
+# CLAUDE_HOOK_SELFTEST: set this env var to run the embedded self-tests. This marker
+# line is how `claude-hook-selftests` discovers participating hooks. A safety hook
+# without a test is theater; run these with `CLAUDE_HOOK_SELFTEST=1 claude-git-dash-c-check`.
+if [[ -n "${CLAUDE_HOOK_SELFTEST:-}" ]]; then
+  SELF=$(realpath "$0")
+  fails=0
+  workdir=$(realpath "$(mktemp -d)")
+  trap 'rm -rf "$workdir"' EXIT
+
+  repo="$workdir/repo"
+  other="$workdir/other"
+  mkdir -p "$repo/sub" "$other"
+  git init -q "$repo"
+  git init -q "$other"
+
+  t() {
+    local desc="$1" cwd="$2" command="$3" want_exit="$4" got_exit=0
+    jq -n --arg cmd "$command" '{tool_input: {command: $cmd}}' \
+      | (cd "$cwd" && CLAUDE_HOOK_SELFTEST= "$SELF") >/dev/null 2>&1 || got_exit=$?
+    [[ "$got_exit" == "$want_exit" ]] ||
+    { printf 'FAIL %s: want_exit=%s got_exit=%s :: %s (cwd=%s)\n' \
+      "$desc" "$want_exit" "$got_exit" "$command" "$cwd"; fails=1; }
+  }
+
+  t "git -C <repo root> blocks"      "$repo"     "git -C $repo status"              2
+  t "git -C . blocks"                "$repo"     "git -C . status"                  2
+  t "git -C from a subdir blocks"    "$repo/sub" "git -C $repo log"                 2
+  t "git -C other repo allows"       "$repo"     "git -C $other status"             0
+  t "plain git allows"               "$repo"     "git status"                       0
+  t "outside any repo allows"        "$workdir"  "git -C $repo status"              0
+  t "-C after && still detected"     "$repo"     "echo hi && git -C . status"       2
+  t "first of multiple -C wins"      "$repo"     "git -C $other status; git -C $repo log" 0
+
+  if [[ "$fails" == 0 ]]; then
+    echo "$(basename "$0"): all self-tests passed"
+  fi
+  exit "$fails"
+fi
+
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command')
 


### PR DESCRIPTION
This PreToolUse hook blocks `git -C <dir>` when <dir> resolves to the current repo, but unlike the other guardrail hooks under PreToolUse (claude-awk-check, claude-rm-scope-check, claude-http-server-bind-check, claude-read-check, claude-shell-comment-check, claude-gh-api-check), it carried no CLAUDE_HOOK_SELFTEST marker, so claude-hook-selftests never exercised it. A safety hook without a test is theater: it could regress silently and nothing would notice.

Added the bash-native selftest pattern used by claude-notify-push (the other hook without a Python schema): build two throwaway git repos, invoke the hook via its own JSON stdin contract from various cwds, and assert on exit code (0 = allow, 2 = block). Cases cover blocking on the repo root itself, on `.`, from a subdirectory of the repo, after a `&&` separator, and allowing a different repo, a plain `git` call, running outside any repo, and the first-match-wins behavior when a command has two `-C` invocations.

CLAUDE.md documented claude-git-dash-c-check as one of the hooks that "stays un-self-tested" because it "needs a specific git repo." That was true until now: updated the passage to describe the mktemp-sandbox technique this change uses to satisfy exactly that need, and moved claude-git-dash-c-check off the still-un-self-tested list (which now reads claude-uv-check and claude-user-away).

Verified with `pre-commit run --files CLAUDE.md bin/claude-git-dash-c-check --verbose` (runs claude-hook-selftests plus beautysh, which reformatted the new bash block on first pass; reran clean). Also proved the new tests can fail: commented out the block condition, reran, watched 4 of 8 cases report FAIL with the expected want/got exit codes, then reverted. Did not touch claude-uv-check, the other PreToolUse hook missing a selftest; it needs a uv project fixture and the `git root` alias from dotrc/gitconfig, which is a bit more setup than fits this change. Left for a follow-up run.

Escapement-Run: dotfiles-improvements-2026-08-10-23-06-38-c018
Agent-Session: d3fc29e4-ba53-4f68-a711-0ab14cee993b