### PR TITLE
Add self-tests to claude-uv-check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,9 +147,10 @@ tests can't run exits non-zero.
   building one with `git init` in a `mktemp -d` sandbox and `cd`-ing into it before
   re-invoking the hook is enough: `claude-git-dash-c-check` does this to test
   blocking on the repo root, on `.`, and from a subdirectory, while allowing a
-  different repo. What stays un-self-tested is state no stub stands in for:
-  `claude-uv-check` needs a uv project, `claude-user-away` a terminal someone has
-  typed into.
+  different repo. `claude-uv-check` uses the same sandbox, `touch`-ing a `uv.lock`
+  in one repo and not the other so the fixture covers both the "not a uv project"
+  and "python invoked directly" branches. What stays un-self-tested is state no
+  stub stands in for: `claude-user-away` needs a terminal someone has typed into.
 - A passing self-test that cannot fail is worth nothing, so confirm a new case catches
   a deliberately broken copy of the hook before trusting it.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,13 @@ tests can't run exits non-zero.
   in one repo and not the other so the fixture covers both the "not a uv project"
   and "python invoked directly" branches. What stays un-self-tested is state no
   stub stands in for: `claude-user-away` needs a terminal someone has typed into.
+- The installed environment is ambient state too, and CI has none of it: no `dotfiles/bin`
+  on PATH and no gitconfig, so a hook that calls a sibling script by name reaches nothing
+  and its guard clause passes every case. A hook that shells out to `bin/` prepends its own
+  directory to PATH in the self-test (`claude-uv-check`), and a `bin/` script spells out the
+  git plumbing rather than using a gitconfig alias (`is-uv-project`, `is-pre-commit-project`
+  call `git rev-parse --show-toplevel`, not `git root`). Both failures are invisible locally,
+  where PATH and gitconfig are installed, so a green local run says nothing about either.
 - A passing self-test that cannot fail is worth nothing, so confirm a new case catches
   a deliberately broken copy of the hook before trusting it.
 

--- a/bin/claude-uv-check
+++ b/bin/claude-uv-check
@@ -8,6 +8,10 @@ set -euo pipefail
 # without a test is theater; run these with `CLAUDE_HOOK_SELFTEST=1 claude-uv-check`.
 if [[ -n "${CLAUDE_HOOK_SELFTEST:-}" ]]; then
   SELF=$(realpath "$0")
+  # In a real session `bin/` is on PATH, so the hook reaches `is-uv-project` by name. A CI
+  # checkout has no such PATH, and without this the guard would silently pass every case.
+  PATH="$(dirname "$SELF"):$PATH"
+  export PATH
   fails=0
   workdir=$(realpath "$(mktemp -d)")
   trap 'rm -rf "$workdir"' EXIT

--- a/bin/claude-uv-check
+++ b/bin/claude-uv-check
@@ -3,6 +3,45 @@
 
 set -euo pipefail
 
+# CLAUDE_HOOK_SELFTEST: set this env var to run the embedded self-tests. This marker
+# line is how `claude-hook-selftests` discovers participating hooks. A safety hook
+# without a test is theater; run these with `CLAUDE_HOOK_SELFTEST=1 claude-uv-check`.
+if [[ -n "${CLAUDE_HOOK_SELFTEST:-}" ]]; then
+  SELF=$(realpath "$0")
+  fails=0
+  workdir=$(realpath "$(mktemp -d)")
+  trap 'rm -rf "$workdir"' EXIT
+
+  uv_project="$workdir/uv_project"
+  plain_project="$workdir/plain_project"
+  mkdir -p "$uv_project" "$plain_project"
+  git init -q "$uv_project"
+  git init -q "$plain_project"
+  touch "$uv_project/uv.lock"
+
+  t() {
+    local desc="$1" cwd="$2" command="$3" want_exit="$4" got_exit=0
+    jq -n --arg cmd "$command" '{tool_input: {command: $cmd}}' \
+      | (cd "$cwd" && CLAUDE_HOOK_SELFTEST= "$SELF") >/dev/null 2>&1 || got_exit=$?
+    [[ "$got_exit" == "$want_exit" ]] ||
+    { printf 'FAIL %s: want_exit=%s got_exit=%s :: %s (cwd=%s)\n' \
+      "$desc" "$want_exit" "$got_exit" "$command" "$cwd"; fails=1; }
+  }
+
+  t "plain python blocked in uv project"        "$uv_project"    "python foo.py"                        2
+  t "python3 blocked in uv project"             "$uv_project"    "python3 foo.py"                       2
+  t "uv run python allowed in uv project"       "$uv_project"    "uv run python foo.py"                 0
+  t "python after && blocked"                   "$uv_project"    "echo hi && python foo.py"             2
+  t "python in package name allowed"            "$uv_project"    "uv pip install python-dotenv"         0
+  t "quoted python in grep pattern allowed"     "$uv_project"    'grep "requires-python\|python" x.toml' 0
+  t "plain python allowed outside uv project"   "$plain_project" "python foo.py"                        0
+
+  if [[ "$fails" == 0 ]]; then
+    echo "$(basename "$0"): all self-tests passed"
+  fi
+  exit "$fails"
+fi
+
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command')
 

--- a/bin/is-pre-commit-project
+++ b/bin/is-pre-commit-project
@@ -3,5 +3,7 @@
 
 set -euo pipefail
 
-root="$(git root)"
+# Spelled out rather than via the `root` gitconfig alias: this runs from hook subprocesses
+# and CI, neither of which is guaranteed to have the dotfiles' gitconfig installed.
+root="$(git rev-parse --show-toplevel)"
 [[ -f "$root/.pre-commit-config.yaml" || -f "$root/.pre-commit-config.yml" ]]

--- a/bin/is-uv-project
+++ b/bin/is-uv-project
@@ -3,4 +3,6 @@
 
 set -euo pipefail
 
-[[ -f "$(git root)/uv.lock" ]]
+# Spelled out rather than via the `root` gitconfig alias: this runs from hook subprocesses
+# and CI, neither of which is guaranteed to have the dotfiles' gitconfig installed.
+[[ -f "$(git rev-parse --show-toplevel)/uv.lock" ]]


### PR DESCRIPTION
This PreToolUse hook blocks bare `python` invocations in a uv project, but had no CLAUDE_HOOK_SELFTEST marker, so claude-hook-selftests never exercised it. It was the last guardrail hook (besides claude-user-away, which genuinely needs a terminal someone typed into) left off that list; commit 214e2fb already added this pattern to claude-git-dash-c-check and explicitly deferred claude-uv-check because it needs a uv project fixture plus the `git root` alias.

Reused the mktemp-sandbox technique: two throwaway git repos, one with a touched uv.lock (uv project) and one without (plain project), invoked via the hooks own JSON stdin contract from each cwd. Cases cover a bare `python` and `python3` call blocked in the uv project, `uv run python` allowed, blocking after a `&&` separator, `python` inside a package name (python-dotenv) and inside a quoted grep pattern both allowed, and a bare `python` call allowed outside any uv project. Updated the CLAUDE.md passage documenting which hooks stay un-self-tested and why, since claude-uv-check no longer belongs on that list.

Verified with `pre-commit run --files CLAUDE.md bin/claude-uv-check --verbose` (runs claude-hook-selftests along with the rest of the pre-commit suite); all 9 self-tested hooks pass. Also proved the new cases can fail: temporarily forced the block condition to `false`, reran, watched the 3 blocking cases report FAIL with the expected want/got exit codes, then reverted.

Escapement-Run: dotfiles-improvements-2026-08-11-13-32-03-d09d
Agent-Session: 9fb04614-9e05-430f-8f6c-eb69e72ebe0e