### PR TITLE
Add self-tests to claude-python-version

### DIFF
--- a/bin/claude-python-version
+++ b/bin/claude-python-version
@@ -5,6 +5,49 @@
 
 set -euo pipefail
 
+# CLAUDE_HOOK_SELFTEST: set this env var to run the hook's embedded self-tests. This
+# marker line is how `claude-hook-selftests` discovers participating hooks. The hook
+# always exits 0, so the tests assert on stdout instead: silence for a non-Python
+# project, and the right pinned/floor version surfacing for one.
+if [[ -n "${CLAUDE_HOOK_SELFTEST:-}" ]]; then
+  SELF=$(realpath "$0")
+  fails=0
+  workdir=$(realpath "$(mktemp -d)")
+  trap 'rm -rf "$workdir"' EXIT
+
+  plain="$workdir/plain"
+  pinned="$workdir/pinned"
+  floor="$workdir/floor"
+  both="$workdir/both"
+  mkdir -p "$plain" "$pinned" "$floor" "$both"
+  echo "3.12" >"$pinned/.python-version"
+  printf '[project]\nrequires-python = ">=3.11"\n' >"$floor/pyproject.toml"
+  echo "3.13.1" >"$both/.python-version"
+  printf '[project]\nrequires-python = ">=3.10"\n' >"$both/pyproject.toml"
+
+  t() {
+    local desc="$1" dir="$2" want="$3" out
+    out=$(cd "$dir" && CLAUDE_HOOK_SELFTEST= "$SELF" 2>&1)
+    if [[ "$want" == "<empty>" ]]; then
+      [[ -z "$out" ]] || { printf 'FAIL %s: want empty, got:\n%s\n' "$desc" "$out"; fails=1; }
+    else
+      [[ "$out" =~ $want ]] || { printf 'FAIL %s: want match /%s/, got:\n%s\n' "$desc" "$want" "$out"; fails=1; }
+    fi
+  }
+
+  t "non-python project stays silent"      "$plain"  "<empty>"
+  t "pinned version surfaces"              "$pinned" 'Pinned interpreter \(\.python-version\): Python 3\.12'
+  t "pinned version links whatsnew"        "$pinned" 'whatsnew/3\.12\.html'
+  t "requires-python floor surfaces"       "$floor"  'requires-python = ">=3\.11"'
+  t "requires-python floor links whatsnew" "$floor"  'whatsnew/3\.11\.html'
+  t "pinned wins over floor for whatsnew"  "$both"   'whatsnew/3\.13\.html'
+
+  if [[ "$fails" == 0 ]]; then
+    echo "$(basename "$0"): all self-tests passed"
+  fi
+  exit "$fails"
+fi
+
 root=$(git rev-parse --show-toplevel 2>/dev/null) || root="$PWD"
 
 pinned=""


### PR DESCRIPTION
This SessionStart hook was on the list of hooks lacking the CLAUDE_HOOK_SELFTEST marker that claude-hook-selftests discovers by. Its version-detection logic (pinned vs. floor precedence, regex extraction from .python-version and pyproject.toml, staying silent on a non-Python project) is exactly the kind of branching the self-test convention exists to catch, and unlike claude-gh-status or claude-user-away it needs no network or terminal, only files on disk, so it sandboxes cleanly in a mktemp dir.

The hook always exits 0, so the tests assert on stdout content rather than exit code, following the pattern already used by claude-notify-push. Verified by running CLAUDE_HOOK_SELFTEST=1 via `pre-commit run claude-hook-selftests --verbose` (passes, and the new hook appears in the per-hook summary alongside the existing 12), then deliberately breaking the whatsnew URL formatting and re-running to confirm three of the six new assertions fail as expected before reverting. Also ran the full `pre-commit run` suite clean.

---

Opened by Escapement for run `dotfiles-improvements-2026-08-14-13-51-23-91d3` of loop [`dotfiles/improvements`](https://github.int.exe.xyz/JoshKarpel/dotfiles/blob/5997bd204c0956f3a7773bb9c2c856ea5175f922/.escapement/loops/improvements.yaml), cut from `origin/master`.

Review it as you would any other pull request. To have the agent answer your review, apply the `escapement:respond` label: it will open one more session on this branch and post what it says as a review. That may happen at most 3 time(s) for this run. Escapement will also answer failing checks on commits it pushed here, without being asked, until this loop's budget is spent.