### PR TITLE
Add self-tests to claude-git-status

### DIFF
--- a/bin/claude-git-status
+++ b/bin/claude-git-status
@@ -9,6 +9,11 @@ set -euo pipefail
 # `CLAUDE_HOOK_SELFTEST=1 claude-git-status`.
 if [[ -n "${CLAUDE_HOOK_SELFTEST:-}" ]]; then
   SELF=$(realpath "$0")
+  # In a real session `bin/` is on PATH, so this hook reaches `git-default-branch` by
+  # name. A CI checkout has no such PATH, and without this the nested self-invocation
+  # below would die on "command not found" and the self-test would abort silently.
+  PATH="$(dirname "$SELF"):$PATH"
+  export PATH
   fails=0
   workdir=$(realpath "$(mktemp -d)")
   trap 'rm -rf "$workdir"' EXIT

--- a/bin/claude-git-status
+++ b/bin/claude-git-status
@@ -3,6 +3,72 @@
 
 set -euo pipefail
 
+# CLAUDE_HOOK_SELFTEST: set this env var to run the embedded self-tests. This marker
+# line is how `claude-hook-selftests` discovers participating hooks. The branch-vs-default
+# and ahead-vs-even branches are easy to get backwards silently; run these with
+# `CLAUDE_HOOK_SELFTEST=1 claude-git-status`.
+if [[ -n "${CLAUDE_HOOK_SELFTEST:-}" ]]; then
+  SELF=$(realpath "$0")
+  fails=0
+  workdir=$(realpath "$(mktemp -d)")
+  trap 'rm -rf "$workdir"' EXIT
+
+  repo="$workdir/repo"
+  mkdir -p "$repo"
+  git init -q -b main "$repo"
+  git -C "$repo" config user.email "test@example.com"
+  git -C "$repo" config user.name "test"
+  echo base >"$repo/file"
+  git -C "$repo" add file
+  git -C "$repo" commit -q -m init
+
+  call() {
+    local cwd="$1"
+    OUT=$(cd "$cwd" && CLAUDE_HOOK_SELFTEST= "$SELF" 2>&1)
+  }
+
+  check_contains() {
+    local desc="$1" needle="$2"
+    [[ "$OUT" == *"$needle"* ]] ||
+    { printf 'FAIL %s: expected output to contain %q :: %s\n' "$desc" "$needle" "$OUT"; fails=1; }
+  }
+
+  check_not_contains() {
+    local desc="$1" needle="$2"
+    [[ "$OUT" != *"$needle"* ]] ||
+    { printf 'FAIL %s: expected output to NOT contain %q :: %s\n' "$desc" "$needle" "$OUT"; fails=1; }
+  }
+
+  call "$workdir"
+  [[ -z "$OUT" ]] || { printf 'FAIL outside any repo: expected no output :: %s\n' "$OUT"; fails=1; }
+
+  call "$repo"
+  check_contains "on the default branch" "Current git status:"
+  check_not_contains "on the default branch" "Recent commits:"
+  check_not_contains "on the default branch" "Net changes vs."
+
+  git -C "$repo" checkout -q -b even
+  call "$repo"
+  check_contains "on a branch with no commits ahead" "Current git status:"
+  check_not_contains "on a branch with no commits ahead" "Recent commits:"
+  check_not_contains "on a branch with no commits ahead" "Net changes vs."
+
+  git -C "$repo" checkout -q -b ahead
+  echo more >>"$repo/file"
+  git -C "$repo" commit -q -am ahead
+  call "$repo"
+  check_contains "on a branch ahead of default" "Current git status:"
+  check_contains "on a branch ahead of default" "Recent commits:"
+  check_contains "on a branch ahead of default" "ahead"
+  check_contains "on a branch ahead of default" "Net changes vs. main (merge-base):"
+  check_contains "on a branch ahead of default" "file"
+
+  if [[ "$fails" == 0 ]]; then
+    echo "$(basename "$0"): all self-tests passed"
+  fi
+  exit "$fails"
+fi
+
 STATUS=$(git status --short --branch 2>/dev/null) || exit 0
 
 CURRENT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null) || CURRENT_BRANCH=""


### PR DESCRIPTION
claude-git-status is a registered SessionStart hook with real branching (default-branch vs. other, ahead vs. even with the default branch) but, unlike its siblings claude-git-dash-c-check and claude-changeset-guard, carried no CLAUDE_HOOK_SELFTEST block, so claude-hook-selftests never exercised it and a silent regression in which sections print would go unnoticed.

Added a self-test following the established git-sandbox pattern (git init -b main in a mktemp dir, mkrepo-style setup): asserts no output outside a repo, no "Recent commits"/"Net changes" sections on the default branch or on a branch with zero commits ahead, and both sections present with real content when ahead. Verified with pre-commit run --all-files (green) and by deliberately breaking two conditions (the branch-equality check, and the empty-LOG guard) to confirm the self-test both does and does not catch the right things: the branch-equality mutation turned out to be behaviorally inert (LOG/DIFFSTAT are empty either way when on the default branch, so nothing prints), which is worth knowing but not a reason to add more assertions; the empty-LOG-guard mutation was caught immediately, then reverted. Could not run claude-git-status or claude-hook-selftests directly via the Bash tool in this unattended session (arbitrary script execution is outside its permission allow-list, which only permits e.g. `pre-commit run*`), so all verification went through `pre-commit run`, which wires in claude-hook-selftests already.

---

Opened by Escapement for run `dotfiles-improvements-2026-08-15-10-01-02-791b` of loop [`dotfiles/improvements`](https://github.int.exe.xyz/JoshKarpel/dotfiles/blob/a3443eaab8fcdf023d7c7ebe1083cecdf6b9e592/.escapement/loops/improvements.yaml), cut from `origin/master`.

Review it as you would any other pull request. To have the agent answer your review, apply the `escapement:respond` label: it will open one more session on this branch and post what it says as a review. That may happen at most 3 time(s) for this run. Escapement will also answer failing checks on commits it pushed here, without being asked, until this loop's budget is spent.