### PR TITLE
Add self-tests to claude-sound

### DIFF
--- a/bin/claude-sound
+++ b/bin/claude-sound
@@ -4,6 +4,50 @@
 
 set -euo pipefail
 
+# CLAUDE_HOOK_SELFTEST: set this env var to run the hook's embedded self-tests. This
+# marker line is how `claude-hook-selftests` discovers participating hooks. The hook
+# always exits 0, so the tests stub `uname` (to reach both the Darwin and Linux
+# branches from one machine) and the player command, and assert on the exit code plus
+# which sound file the stub was invoked with, or that no player ran at all.
+if [[ -n "${CLAUDE_HOOK_SELFTEST:-}" ]]; then
+  fails=0
+  t() {
+    local want="$1" uname_out="$2" player="$3" installed="$4" player_exit="$5" test_role="$6"
+    local stubs got exit_code
+    stubs=$(mktemp -d)
+    printf '#!/usr/bin/env bash\necho %s\n' "$uname_out" >"$stubs/uname"
+    chmod +x "$stubs/uname"
+    if [[ "$installed" == "1" ]]; then
+      printf '#!/usr/bin/env bash\nprintf %%s "${@: -1}" >"%s/played"\nexit %s\n' \
+        "$stubs" "$player_exit" >"$stubs/$player"
+      chmod +x "$stubs/$player"
+    fi
+    PATH="$stubs:$PATH" CLAUDE_HOOK_SELFTEST= "$0" $test_role >/dev/null 2>&1
+    exit_code=$?
+    if [[ -e "$stubs/played" ]]; then
+      got="exit=$exit_code played=$(basename "$(cat "$stubs/played")")"
+    else
+      got="exit=$exit_code played=none"
+    fi
+    rm -rf "$stubs"
+    [[ "$got" == "$want" ]] ||
+    { printf 'FAIL want=%s got=%s :: %s %s installed=%s player_exit=%s role=%s\n' \
+      "$want" "$got" "$uname_out" "$player" "$installed" "$player_exit" "$test_role"; fails=1; }
+  }
+  t 'exit=0 played=complete.oga' Linux paplay 1 0 stop
+  t 'exit=0 played=message.oga'  Linux paplay 1 0 notify
+  t 'exit=0 played=complete.oga' Linux paplay 1 0 ''      # no role arg defaults to stop
+  t 'exit=0 played=none'         Linux paplay 0 0 stop    # paplay not installed
+  t 'exit=0 played=complete.oga' Linux paplay 1 1 stop    # paplay installed but fails (no audio server)
+  t 'exit=0 played=Morse.aiff'   Darwin afplay 1 0 stop
+  t 'exit=0 played=Ping.aiff'    Darwin afplay 1 0 notify
+  t 'exit=0 played=none'         Darwin afplay 0 0 stop   # afplay not installed
+  if [[ "$fails" == 0 ]]; then
+    echo "$(basename "$0"): all self-tests passed"
+  fi
+  exit "$fails"
+fi
+
 role="${1:-stop}"
 
 # A player that is installed but can't reach an audio server fails at playback rather


### PR DESCRIPTION
claude-sound is a Notification/Stop hook that always exits 0 and swallows player failures by design (no speakers on a headless VM must stay silent in both senses), so there was no exit code to assert on and no self-tests. Stub uname on PATH to reach both the Darwin and Linux branches from one machine, stub the player command to record which sound file it was invoked with, and assert on the (exit code, played file) pair: correct file per role, default role, player not installed, and player installed but failing (the actual headless-VM case).

Verified with `pre-commit run` (repo-wide): all hooks pass, including claude-hook-selftests, which discovers the new tests via the CLAUDE_HOOK_SELFTEST marker. Also proved the tests can fail: temporarily swapped the stop/notify sound files, reran pre-commit, watched all four affected cases fail with the expected want/got mismatch, then reverted.

---

Opened by Escapement for run `dotfiles-improvements-2026-08-16-10-00-39-43ef` of loop [`dotfiles/improvements`](https://github.int.exe.xyz/JoshKarpel/dotfiles/blob/cde99aa4f3fed853377ea5f285a7271f95b78ceb/.escapement/loops/improvements.yaml), cut from `origin/master`.

Review it as you would any other pull request. To have the agent answer your review, apply the `escapement:respond` label: it will open one more session on this branch and post what it says as a review. That may happen at most 3 time(s) for this run. Escapement will also answer failing checks on commits it pushed here, without being asked, until this loop's budget is spent.